### PR TITLE
Mods integration

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -101,7 +101,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'cobject_title_ssi', label: 'Title'
     config.add_show_field 'creator_tsim', label: 'Creator'
     config.add_show_field 'description_tsim', label: 'Description'
-    # config.add_show_field 'mods_ts', label: 'mods'
+    config.add_show_field 'mods_ts', label: 'mods',  helper_method: :show_mods_record
 
 
     # "fielded" search configuration. Used by pulldown among other places.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,10 +17,11 @@ module ApplicationHelper
   def show_mods_record args
     # Get hold of the mods record from the solr doc and transform it in relation to the medium
     mods = args[:document]['mods_ts']
+    xslt_file = 'mods_renderer_' + params['medium'] + '.xsl'
     mods_dom = Nokogiri::XML(mods)
-    xslt_file           = Rails.root.join('config', 'mods_views', 'mods_renderer_images.xsl')
+    xslt_file_path      = Rails.root.join('config', 'mods_views', xslt_file )
     lang_selector_sheet = Rails.root.join('config', 'mods_views', 'choose_lang.xsl')
-    stylesheet          = Nokogiri::XSLT(File.open(xslt_file))
+    stylesheet          = Nokogiri::XSLT(File.open(xslt_file_path))
     lang_selector       = Nokogiri::XSLT(File.open(lang_selector_sheet))
     transformed_doc     = lang_selector.transform(stylesheet.transform(mods_dom, {}),["lang","'da'"])
     transformed_doc.to_s.html_safe

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,4 +14,16 @@ module ApplicationHelper
     doc['node_tdsim'].first unless doc['node_tdsim'].blank?
   end
 
+  def show_mods_record args
+    # Get hold of the mods record from the solr doc and transform it in relation to the medium
+    mods = args[:document]['mods_ts']
+    mods_dom = Nokogiri::XML(mods)
+    xslt_file           = Rails.root.join('config', 'mods_views', 'mods_renderer_images.xsl')
+    lang_selector_sheet = Rails.root.join('config', 'mods_views', 'choose_lang.xsl')
+    stylesheet          = Nokogiri::XSLT(File.open(xslt_file))
+    lang_selector       = Nokogiri::XSLT(File.open(lang_selector_sheet))
+    transformed_doc     = lang_selector.transform(stylesheet.transform(mods_dom, {}),["lang","'da'"])
+    transformed_doc.to_s.html_safe
+  end
+
 end

--- a/config/mods_views/choose_lang.xsl
+++ b/config/mods_views/choose_lang.xsl
@@ -1,37 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-               xmlns="http://www.w3.org/1999/xhtml"
-               xmlns:h="http://www.w3.org/1999/xhtml"
-               xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/"
-               xmlns:atom="http://www.w3.org/2005/Atom"
-               xmlns:dc="http://purl.org/dc/elements/1.1/"
-               xmlns:dcterms="http://purl.org/dc/terms/"
-               xmlns:xalan="http://xml.apache.org/xslt"
-               xmlns:string="xalan://java.lang.String"
-               xmlns:tei="http://www.tei-c.org/ns/1.0"
-               xmlns:kb="http://www.kb.dk/insert/"
-               xmlns:xlink="http://www.w3.org/1999/xlink"
-               xmlns:md="http://www.loc.gov/mods/v3"
-               exclude-result-prefixes="h xsl kb md string xlink dcterms dc atom opensearch xalan tei"
                version="1.0">
-
-    <!--
-        Script that implements language selection. It traverses a HTML
-        page and supresses the printing of one language (Danish or English)
-        Author: Sigfrid Lundberg (slu@kb.dk)
-        $Revision: 1.11 $ last modified $Date: 2011-03-31 12:18:13 $ by $Author: slu $
-        $Id: choose_lang.xsl,v 1.11 2011-03-31 12:18:13 slu Exp $
-    -->
-
-
-    <xsl:param name="path" select="''"/>
-
-    <xsl:param name="query_string" select="''"/>
-    <xsl:param name="myQuery">
-        <xsl:if test="$query_string">
-            <xsl:value-of select="concat('?',$query_string)"/>
-        </xsl:if>
-    </xsl:param>
 
     <xsl:param name="lang" select="'en'"/>
     <xsl:param name="suppress_lang">
@@ -53,78 +22,12 @@
         <xsl:apply-templates/>
     </xsl:template>
 
-    <xsl:template match="node()[@class = 'language']">
-        <xsl:element name="a">
-            <xsl:attribute name="href">
-                <xsl:choose>
-                    <xsl:when test="string-length(substring-after($path,concat('/',$lang))) = 0">
-                        <xsl:value-of select="concat(substring-before($path,concat('/',$lang)),
-				  '/',$suppress_lang,'/',
-				  $myQuery)"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of select="concat(substring-before($path,concat('/',$lang,'/')),
-				  '/',$suppress_lang,'/',
-				  substring-after($path,concat('/',$lang,'/')),
-				  $myQuery)"/>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:attribute>
-            <xsl:attribute name="class">language</xsl:attribute>
-            <xsl:attribute name="xml:lang">
-                <xsl:value-of select="$suppress_lang"/>
-            </xsl:attribute>
-            <xsl:choose>
-                <xsl:when test="$lang = 'da'">English</xsl:when>
-                <xsl:otherwise>Dansk</xsl:otherwise>
-            </xsl:choose>
-        </xsl:element>
-    </xsl:template>
-
-    <xsl:template name="form">
-        <xsl:element name="form">
-            <xsl:attribute name="method">get</xsl:attribute>
-            <xsl:attribute name="action"></xsl:attribute>
-            <xsl:attribute name="accept-charset">UTF-8</xsl:attribute>
-            <xsl:attribute name="id">search-form</xsl:attribute>
-            <xsl:apply-templates select="node()"/>
-        </xsl:element>
-    </xsl:template>
-
-    <xsl:template match="node()[@xml:lang = $suppress_lang]">
-    </xsl:template>
-
     <xsl:template match="@*|node()">
-        <xsl:choose>
-            <xsl:when test="name(.)='form'">
-                <xsl:call-template name="form"/>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:copy>
-                    <xsl:apply-templates select="@*|node()"/>
-                </xsl:copy>
-            </xsl:otherwise>
-        </xsl:choose>
+      <xsl:if test="not(@xml:lang=$suppress_lang)">
+	<xsl:copy>
+	  <xsl:apply-templates select="@*|node()"/>
+	</xsl:copy>
+      </xsl:if>
     </xsl:template>
 
 </xsl:transform>
-
-
-        <!--
-            $Log: not supported by cvs2svn $
-            Revision 1.10  2009/06/26 11:50:26  slu
-            implemented workaround for searching
-
-            Revision 1.9  2009/06/04 07:36:32  slu
-            Added an extensive exclude-result-prefixes
-
-            Revision 1.8  2009/04/14 10:38:17  slu
-            Now with proper metadata and RCS tags
-
-            Revision 1.7  2009/04/14 10:36:53  slu
-            no comments
-
-            Revision 1.6  2009/04/14 10:36:32  slu
-            No correctly handling URIs with a trailing language tag (da or en)
-            without a trailing slash.
-        -->

--- a/config/mods_views/mods_renderer_books.xsl
+++ b/config/mods_views/mods_renderer_books.xsl
@@ -33,10 +33,6 @@ This xsl does the formatting of metadata for a landing page
     <xsl:element name="div">
       <xsl:attribute name="class">rightGrid</xsl:attribute>
       <section id="metaData">
-	<header>
-	  <h2 xml:lang="da">Fakta</h2>
-	  <h2 xml:lang="en">Facts</h2>
-	</header>
 	<ul>
 	  <!-- START METADATAELEMENTS -->
 	  <!--  START TITLE ELEMENTS -->
@@ -49,22 +45,20 @@ This xsl does the formatting of metadata for a landing page
 		  <strong xml:lang="en">Title:</strong>
 		  <xsl:element name="span">
 		    <xsl:attribute name="dir">ltr</xsl:attribute>
-		    <xsl:element name="span">
-		      <xsl:attribute name="lang">
-			<xsl:call-template name="get_language">
-			  <xsl:with-param name="cataloging_language" select="$cataloging_language" />
-			</xsl:call-template>
-		      </xsl:attribute>
+		    <xsl:attribute name="lang">
+		      <xsl:call-template name="get_language">
+			<xsl:with-param name="cataloging_language" select="$cataloging_language" />
+		      </xsl:call-template>
+		    </xsl:attribute>
 		      <xsl:apply-templates select="(md:nonSort|md:title)[not(@transliteration='rex')]"/>
-		    </xsl:element>
-		    <xsl:element name="span">
-		      <xsl:attribute name="lang">
-			<xsl:call-template name="get_language">
-			  <xsl:with-param name="cataloging_language" select="$cataloging_language" />
-			</xsl:call-template>
-		      </xsl:attribute>
-		      <xsl:if test="position()&lt;last() and last()&gt;1"><xsl:text>; </xsl:text></xsl:if>
-		    </xsl:element>
+		  </xsl:element>
+		  <xsl:element name="span">
+		    <xsl:attribute name="lang">
+		      <xsl:call-template name="get_language">
+			<xsl:with-param name="cataloging_language" select="$cataloging_language" />
+		      </xsl:call-template>
+		    </xsl:attribute>
+		    <xsl:if test="position()&lt;last() and last()&gt;1"><xsl:text>; </xsl:text></xsl:if>
 		  </xsl:element>
 		</xsl:if>
 		<xsl:text>

--- a/config/mods_views/mods_renderer_images.xsl
+++ b/config/mods_views/mods_renderer_images.xsl
@@ -36,12 +36,7 @@ in the metadatasection of a landing page -->
     <xsl:element name="div">
       <xsl:attribute name="class">rightGrid</xsl:attribute>
       <section id="metaData">
-	<header>
-	  <h2 xml:lang="da">Fakta</h2>
-	  <h2 xml:lang="en">Facts</h2>
-	</header>
 	<ul>
-
 	  <!-- START METADATAELEMENTS -->
 	  <!--  START TITLE ELEMENTS -->
 	  <!-- START TITLE -->

--- a/config/mods_views/mods_renderer_images.xsl
+++ b/config/mods_views/mods_renderer_images.xsl
@@ -350,12 +350,14 @@ in the metadatasection of a landing page -->
 		<strong xml:lang="en">Note:</strong>
 		<strong xml:lang="da">Note:</strong>
 	      </xsl:if>
+	      <span>
 	      <xsl:attribute name="lang">
 		<xsl:call-template name="get_language">
 		  <xsl:with-param name="cataloging_language" select="$cataloging_language" />
 		</xsl:call-template>
 	      </xsl:attribute>
 	      <xsl:value-of select="."/>
+	      </span>
 	      <br/>
 	    </xsl:element>
 	  </xsl:for-each>

--- a/config/mods_views/mods_renderer_letters.xsl
+++ b/config/mods_views/mods_renderer_letters.xsl
@@ -32,10 +32,6 @@ in the metadatasection of a landing page -->
   <xsl:template name="mods_renderer">
     <xsl:attribute name="class">rightGrid</xsl:attribute>
     <section id="metaData">
-      <header>
-	<h2 xml:lang="da">Fakta</h2>
-	<h2 xml:lang="en">Facts</h2>
-      </header>
       <ul>
 	<!-- START METADATAELEMENTS -->
 	<!--  START TITLE ELEMENTS -->

--- a/config/mods_views/mods_renderer_manus.xsl
+++ b/config/mods_views/mods_renderer_manus.xsl
@@ -33,10 +33,6 @@ This xsl does the formatting of metadata for a landing page
     <xsl:element name="div">
       <xsl:attribute name="class">rightGrid</xsl:attribute>
       <section id="metaData">
-	<header>
-	  <h2 xml:lang="da">Fakta</h2>
-	  <h2 xml:lang="en">Facts</h2>
-	</header>
 	<ul>
 	  <!-- START METADATAELEMENTS -->
 	  <!--  START TITLE ELEMENTS -->

--- a/config/mods_views/mods_renderer_maps.xsl
+++ b/config/mods_views/mods_renderer_maps.xsl
@@ -33,10 +33,6 @@ in the metadatasection of a landing page -->
     <xsl:element name="div">
       <xsl:attribute name="class">rightGrid</xsl:attribute>
       <section id="metaData">
-	<header>
-	  <h2 xml:lang="da">Fakta</h2>
-	  <h2 xml:lang="en">Facts</h2>
-	</header>
 	<ul>
 	  <!-- START METADATAELEMENTS -->
 	  <!--  START TITLE ELEMENTS -->

--- a/config/mods_views/mods_renderer_pamphlets.xsl
+++ b/config/mods_views/mods_renderer_pamphlets.xsl
@@ -35,10 +35,6 @@ This xsl does the formatting of metadata for a landing page
     <xsl:element name="div">
       <xsl:attribute name="class">rightGrid</xsl:attribute>
       <section id="metaData">
-	<header>
-	  <h2 xml:lang="da">Fakta</h2>
-	  <h2 xml:lang="en">Facts</h2>
-	</header>
 	<ul>
 	  <!-- START METADATAELEMENTS -->
 	  <!--  START TITLE ELEMENTS -->

--- a/config/mods_views/mods_renderer_pamphlets.xsl
+++ b/config/mods_views/mods_renderer_pamphlets.xsl
@@ -49,8 +49,8 @@ This xsl does the formatting of metadata for a landing page
 		    <xsl:attribute name="dir">ltr</xsl:attribute>
 		    <xsl:element name="span">
 		      <xsl:attribute name="lang">
-			<xsl:call-template name="get_language"
->			  <xsl:with-param name="cataloging_language" select="$cataloging_language" />
+			<xsl:call-template name="get_language">
+			  <xsl:with-param name="cataloging_language" select="$cataloging_language" />
 			</xsl:call-template>
 		      </xsl:attribute>
 		      <xsl:apply-templates select="(md:nonSort|md:title)[not(@transliteration='rex')]"/>

--- a/config/mods_views/mods_renderer_pamphlets.xsl
+++ b/config/mods_views/mods_renderer_pamphlets.xsl
@@ -364,13 +364,15 @@ This xsl does the formatting of metadata for a landing page
 		</xsl:otherwise>
 	      </xsl:choose>
 	      <xsl:for-each select="md:mods/md:genre">
-		<xsl:attribute name="xml:lang">
-		  <xsl:value-of select="@xml:lang"/>
-		</xsl:attribute>
-		<xsl:value-of select="."/>
-		<xsl:call-template name="break_semicolon">
-		  <xsl:with-param name="cataloging_language" select="$cataloging_language" />
-		</xsl:call-template>
+		<span>
+		  <xsl:attribute name="lang">
+		    <xsl:value-of select="@xml:lang"/>
+		  </xsl:attribute>
+		  <xsl:value-of select="."/>
+		  <xsl:call-template name="break_semicolon">
+		    <xsl:with-param name="cataloging_language" select="$cataloging_language" />
+		  </xsl:call-template>
+		</span>
 	      </xsl:for-each>
 	    </xsl:element>
 	  </xsl:if>
@@ -890,18 +892,14 @@ This xsl does the formatting of metadata for a landing page
 		  <xsl:element name="a">
 		    <xsl:attribute name="xml:lang">da</xsl:attribute>
 		    <xsl:attribute name="href">
-		      <xsl:value-of select="concat('/editions/any/2009/jul/editions/da/',
-					    '?query=',$escapedQuery,
-					    '&amp;searchAcrossEditions=true&amp;orderBy=&amp;title=&amp;creator=&amp;person=&amp;location=&amp;notBefore=&amp;notAfter=')"/>
+		      <xsl:value-of select="concat('/','?search_field=all_fields&amp;q=',$escapedQuery)"/>,
 		    </xsl:attribute>
 		    <xsl:value-of select="."/>
 		  </xsl:element>
 		  <xsl:element name="a">
 		    <xsl:attribute name="xml:lang">en</xsl:attribute>
 		    <xsl:attribute name="href">
-		      <xsl:value-of select="concat('/editions/any/2009/jul/editions/en/',
-					    '?query=',$escapedQuery,
-					    '&amp;searchAcrossEditions=true&amp;orderBy=&amp;title=&amp;creator=&amp;person=&amp;location=&amp;notBefore=&amp;notAfter=')"/>
+		      <xsl:value-of select="concat('/','?search_field=all_fields&amp;q=',$escapedQuery)"/>,
 		    </xsl:attribute>
 		    <xsl:value-of select="."/>
 		  </xsl:element>


### PR DESCRIPTION
this pull request contains code that 

(1) prints a html rendition of the MODS on a landing page. The rendition is the same as in old COP. It selects headings for metadata field depending on language choice (hard coded to Danish for the time being)

(2) prints the Is Part of section on landing page. This is actually a part of (1) above.