### PR TITLE
remove the hardcoded route to frontpage and to search in all editions

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,20 +103,15 @@ module ApplicationHelper
     end
   end
 
-  def search_query(opts={:label=>nil})
+  def change_lang_url(opts={:label=>nil})
      scope = opts.delete(:route_set) || self
-     query_params = current_search_session.try(:query_params) || ActionController::Parameters.new
-
-     if search_session['counter']
-       per_page = (search_session['per_page'] || default_per_page).to_i
-       counter = search_session['counter'].to_i
-
-       query_params[:per_page] = per_page unless search_session['per_page'].to_i == default_per_page
-       query_params[:page] = params[:page]? params[:page]:((counter - 1)/ per_page) + 1
+     state = search_state.to_h
+     if 'da'.eql?(state[:locale])
+       state[:locale] = 'en'
+     else
+       state[:locale] = 'da'
      end
-
-     para = current_search_session.try(:query_params)? {"q"=>query_params[:q], "page"=>query_params[:page], "per_page"=>query_params[:per_page], "utf8"=>query_params[:utf8], "search_field"=>query_params[:search_field], "controller"=>query_params[:controller], "locale"=>query_params[:locale]}:query_params.permit!
-     scope.url_for(para).partition('?').last
+     scope.url_for(state)
   end
   
 end

--- a/app/helpers/cop/render_constraints_helper.rb
+++ b/app/helpers/cop/render_constraints_helper.rb
@@ -1,0 +1,21 @@
+module Cop
+  module RenderConstraintsHelper
+    include Blacklight::RenderConstraintsHelperBehavior
+
+    ##
+    # DGJ: we override this function to delete the page param from the remove constraint url
+    # this could be a bug in blacklight
+    def remove_constraint_url(localized_params)
+      scope = localized_params.delete(:route_set) || self
+
+      unless localized_params.is_a? ActionController::Parameters
+        localized_params = ActionController::Parameters.new(localized_params)
+      end
+
+      options = localized_params.merge(q: nil, action: 'index')
+      options.delete(:page) # we do not want to keep the page param, since removing a constrint is a new search and should start on the first page
+      options.permit!
+      scope.url_for(options)
+    end
+  end
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -4,14 +4,14 @@ class SearchBuilder < Blacklight::SearchBuilder
   self.default_processor_chain += [:add_edition,:add_subject,:add_notAfter,:add_notBefore]
 
   def add_edition(solr_parameters)
-    if blacklight_params[:edition].present? && !blacklight_params[:subj_id].present?
+    if blacklight_params[:edition].present? && !'editions'.eql?(blacklight_params[:medium]) && !blacklight_params[:subj_id].present?
       solr_parameters[:fq] << "cobject_edition_ssi:\"/#{blacklight_params[:medium]}/#{blacklight_params[:collection]}/#{blacklight_params[:year]}/#{blacklight_params[:month]}/#{blacklight_params[:edition]}\""
     end
   end
 
   def add_subject(solr_parameters)
-    if blacklight_params[:subj_id].present?
-      solr_parameters[:fq] << "subject_topic_id_ssim:\"/#{blacklight_params[:medium]}/#{blacklight_params[:collection]}/#{blacklight_params[:year]}/#{blacklight_params[:month]}/#{blacklight_params[:edition]}/subject#{blacklight_params[:subj_id]}\""
+    if blacklight_params[:subj_id].present? && !'editions'.eql?(blacklight_params[:medium])
+    solr_parameters[:fq] << "subject_topic_id_ssim:\"/#{blacklight_params[:medium]}/#{blacklight_params[:collection]}/#{blacklight_params[:year]}/#{blacklight_params[:month]}/#{blacklight_params[:edition]}/subject#{blacklight_params[:subj_id]}\""
     end
   end
 

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -10,7 +10,7 @@
   </ul>
 
   <ul class="nav navbar-nav">
-    <li><a href="<%= t('blacklight.header_links.language_path')%>?<%= search_query() %>"> <%= t('blacklight.header_links.change_language_to') %></a></li>
+    <li><a href="<%= change_lang_url %>"> <%= t('blacklight.header_links.change_language_to') %></a></li>
   </ul>
 
   <% if has_user_authentication_provider? %>

--- a/app/views/tree/_show_tree.erb
+++ b/app/views/tree/_show_tree.erb
@@ -1,4 +1,4 @@
-<% subject_id = "/#{params[:medium]}/#{params[:collection]}/#{params[:year]}/#{params[:month]}/#{params[:edition]}/subject#{params[:subj_id]}" unless params[:medium].blank? %>
+<% subject_id = "/#{params[:medium]}/#{params[:collection]}/#{params[:year]}/#{params[:month]}/#{params[:edition]}/subject#{params[:subj_id]}" unless params[:medium].blank? || 'editions'.eql?(params[:medium]) %>
 <% lang = params['locale'] %>
 
 <!--I take the params by splitting the URL, and NOT by using blacklight functionality, because the params returned

--- a/app/views/tree/_show_tree.erb
+++ b/app/views/tree/_show_tree.erb
@@ -3,8 +3,8 @@
 
 <!--I take the params by splitting the URL, and NOT by using blacklight functionality, because the params returned
 different format for the facets (I think it's bug in Blacklight)-->
-<% filter_params_url = "" %>
-<% filter_params_url = '?' + request.original_url.partition('?').last if request.original_url.include?('?') %>
+<% filter_params_url = "?" %>
+<% filter_params_url += search_state.params_for_search.except(:page, :locale, :medium, :collection, :year, :month, :edition, :subj_id).to_query %>
 
 <% if subject_id %>
     <!--Show the tree -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
   end
 
   get ':locale', to: 'catalog#index'
-  get 'editions/any/2009/jul/editions/:locale',   to: 'catalog#index'
+ # get 'editions/any/2009/jul/editions/:locale',   to: 'catalog#index'
   get ':medium/:collection/:year/:month/:edition/:locale',   to: 'catalog#index'
   get ':medium/:collection/:year/:month/:edition/object:obj_id/:locale',   to: 'catalog#show'
   get ':medium/:collection/:year/:month/:edition/subject:subj_id/:locale', to: 'catalog#index'


### PR DESCRIPTION
This fixes the routing problems when searching in all editioins

Should propably be testes by someone else than me

We can also simplify some of the code, but we can leave that for later.