### PR TITLE
do some caching to reduce the number of solr queries for categories

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -4,7 +4,9 @@
 
 <% #exhibits.each_slice(3).each do |row| %>
     <div class="row"><!-- start main content row -->
-      <%= render partial: 'edition_card' %>
+      <% cache('edition-cards', expires_in: 1.hour) do %>
+        <%= render partial: 'edition_card' %>
+      <% end %>
     </div>
 <% #end %>
 

--- a/app/views/tree/_show_tree.erb
+++ b/app/views/tree/_show_tree.erb
@@ -8,7 +8,11 @@ different format for the facets (I think it's bug in Blacklight)-->
 
 <% if subject_id %>
     <!--Show the tree -->
-    <%= render :partial => 'tree/tree', locals: {:subject_id => subject_id, :lang => lang, :filter_params_url => filter_params_url} %>
+    <% cache(subject_id.gsub('/','#'), expires_in: 1.hour) do %>
+       <%= render :partial => 'tree/tree', locals: {:subject_id => subject_id, :lang => lang, :filter_params_url => filter_params_url} %>
+    <% end %>
 <% else %>
-    <%= render :partial => 'tree/tree', locals: {:subject_id => "/editions/any/2009/jul/editions", :lang => lang, :filter_params_url => filter_params_url} %>
+    <% cache('subject-all', expires_in: 1.hour) do %>
+      <%= render :partial => 'tree/tree', locals: {:subject_id => "/editions/any/2009/jul/editions", :lang => lang, :filter_params_url => filter_params_url} %>
+    <% end %>
 <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,19 +12,9 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
-  # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
-    config.action_controller.perform_caching = true
-
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      'Cache-Control' => 'public, max-age=172800'
-    }
-  else
-    config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
-  end
+  #cache settings
+  config.action_controller.perform_caching = true
+  config.cache_store = :memory_store, { size: 64.megabytes }
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,7 +12,13 @@ Rails.application.configure do
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
+
+  #cache settings
   config.action_controller.perform_caching = true
+  config.cache_store = :memory_store, {size: 64.megabytes}
+  config.public_file_server.headers = {
+      'Cache-Control' => 'public, max-age=172800'
+  }
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.


### PR DESCRIPTION
Using rails caching we can reduced the number of solr queries for building the category tree (and flipcards on the frontpage).

I have installed tried it on the testserver at it seems to work and reduce the number of solrqueries significantly.